### PR TITLE
Add README to rfcs folder

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,18 @@
+# RFC (request for comments) Working Documents
+
+The files found here are collaborative notes exploring various proposals for advancing this subcommittee. Documents included in this directory imply no specific approval or support nor are any proposals required to create a document here.
+
+## Disclaimers
+
+* Documents included in this directory imply no specific approval or support for inclusion in the GraphQL spec or other GraphQL projects.
+* Documents here may be historical or out of date.
+* An RFC may be active without being documented here; there is no requirement to add RFCs here.
+
+## Contributing
+
+Pull requests are encouraged. New documents and other non-destructive changes may be merged with a low degree of scrutiny and minimal review.
+
+That said, please follow these suggestions:
+
+* New proposals should be presented in a [working group meeting](../agendas). Submitting a document here is not sufficient or required to introduce a new proposal.
+* Favor documents which define a problem and explore a solution space rather than propose a specific change. The intent of documents found here are to help ask and answer questions to build confidence and advance an RFC.


### PR DESCRIPTION
This retains the folder such that the link in the root README functions.